### PR TITLE
LEB-4936 | Update to validate fetch request responses

### DIFF
--- a/addon/services/request-signer.js
+++ b/addon/services/request-signer.js
@@ -201,14 +201,19 @@ export default Service.extend({
    * Validates a response from the server.
    * @method  validateResponse
    * @public
-   * @param {Object} request: The jQuery jqXHR request sent.
+   * @param {Response} fetchResponse   The Fetch Response received.
+   * @param {String} nonce             The nonce used to sign the Fetch Request.
+   * @param {String} timestamp         The timestamp used to sign the Fetch Request.
    * @return {Promise} the promise resolves with `true` if valid, or `false` otherwise.
    */
   validateResponse(fetchResponse, nonce, timestamp) {
-    assert('The signer must be configured with initializeSigner prior to use.', !isEmpty(this.signer));
+    const signer = this.get('signer');
+
+    assert('The signer must be configured with initializeSigner prior to use.', !isEmpty(signer));
+
     return fetchResponse.text()
-      .then(function(text) {
-        return this.get('signer').hasValidFetchResponse(
+      .then((text) => {
+        return signer.hasValidFetchResponse(
           text,
           fetchResponse.headers,
           nonce,

--- a/addon/services/request-signer.js
+++ b/addon/services/request-signer.js
@@ -186,13 +186,14 @@ export default Service.extend({
     // Allow additional parameters to pass through.
     Object.keys(hash).forEach((propertyName) => {
       if(!standardProperties.includes(propertyName)) {
-        signParameters[propertyName]=hash[propertyName];
+        signParameters[propertyName] = hash[propertyName];
       }
     })
 
-    const signedHeaders = signer.getHeaders(signParameters);
+    const { headers:signedHeaders, nonce, timestamp } = signer.getFetchHeaders(signParameters);
 
     hash.headers = Object.assign(headers, signedHeaders);
+    Object.assign(hash, { nonce, timestamp });
     return hash;
   },
 

--- a/addon/services/request-signer.js
+++ b/addon/services/request-signer.js
@@ -202,10 +202,18 @@ export default Service.extend({
    * @method  validateResponse
    * @public
    * @param {Object} request: The jQuery jqXHR request sent.
-   * @return {boolean} True if valid, false otherwise.
+   * @return {Promise} the promise resolves with `true` if valid, or `false` otherwise.
    */
-  validateResponse(request) {
+  validateResponse(fetchResponse, nonce, timestamp) {
     assert('The signer must be configured with initializeSigner prior to use.', !isEmpty(this.signer));
-    return this.get('signer').hasValidResponse(request);
+    return fetchResponse.text()
+      .then(function(text) {
+        return this.get('signer').hasValidFetchResponse(
+          text,
+          fetchResponse.headers,
+          nonce,
+          timestamp,
+        );
+      });
   }
 });

--- a/addon/services/request-signer.js
+++ b/addon/services/request-signer.js
@@ -201,24 +201,22 @@ export default Service.extend({
    * Validates a response from the server.
    * @method  validateResponse
    * @public
-   * @param {Response} fetchResponse   The Fetch Response received.
-   * @param {String} nonce             The nonce used to sign the Fetch Request.
-   * @param {String} timestamp         The timestamp used to sign the Fetch Request.
+   * @param {String} responseText   The response as text from the Fetch Response.
+   * @param {Object} headers        The headers from the Fetch Response.
+   * @param {String} nonce          The nonce used to sign the Fetch Request.
+   * @param {String} timestamp      The timestamp used to sign the Fetch Request.
    * @return {Promise} the promise resolves with `true` if valid, or `false` otherwise.
    */
-  validateResponse(fetchResponse, nonce, timestamp) {
+  validateResponse(responseText, headers, nonce, timestamp) {
     const signer = this.get('signer');
 
     assert('The signer must be configured with initializeSigner prior to use.', !isEmpty(signer));
 
-    return fetchResponse.text()
-      .then((text) => {
-        return signer.hasValidFetchResponse(
-          text,
-          fetchResponse.headers,
-          nonce,
-          timestamp,
-        );
-      });
+    return signer.hasValidFetchResponse(
+      responseText,
+      headers,
+      nonce,
+      timestamp,
+    );
   }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12030,7 +12030,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -12051,12 +12052,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -12071,17 +12074,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -12198,7 +12204,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -12210,6 +12217,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -12224,6 +12232,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -12231,12 +12240,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -12255,6 +12266,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -12344,7 +12356,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -12356,6 +12369,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -12441,7 +12455,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -12477,6 +12492,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -12496,6 +12512,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -12539,12 +12556,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -13218,8 +13237,8 @@
       }
     },
     "http-hmac-javascript": {
-      "version": "git+https://github.com/acquia/http-hmac-javascript.git#858dbe1caaafeb02c2e34a1e9247875cdbaced51",
-      "from": "git+https://github.com/acquia/http-hmac-javascript.git#v0.2.5",
+      "version": "git+https://github.com/acquia/http-hmac-javascript.git#f06f1a1fdb222dc22f6332ab9df22276a97934cd",
+      "from": "git+https://github.com/acquia/http-hmac-javascript.git#v0.3.0",
       "requires": {
         "crypto-js": "^3.1.6",
         "xmlhttprequest": "^1.8.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-http-hmac",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-http-hmac",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Provides an Ember wrapper around Acquia's http-hmac-javascript library.",
   "scripts": {
     "build": "ember build",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "crypto-js": "^3.1.6",
     "ember-cli-babel": "^7.13.0",
     "ember-cli-htmlbars": "^4.2.0",
-    "http-hmac-javascript": "git+https://github.com/acquia/http-hmac-javascript.git#v0.2.5",
+    "http-hmac-javascript": "git+https://github.com/acquia/http-hmac-javascript.git#v0.3.0",
     "xmlhttprequest": "^1.8.0"
   },
   "devDependencies": {

--- a/tests/unit/services/request-signer-test.js
+++ b/tests/unit/services/request-signer-test.js
@@ -221,14 +221,8 @@ module('Unit | Services | request-signer', function(hooks) {
         assert.equal(timestamp, validTimestamp, 'The timestamp is passed.');
       },
     };
-    const mockResponse = {
-      headers: allHeaders,
-      text() {
-        return Promise.resolve(validText);
-      },
-    };
 
     service.set('signer', signerMock);
-    await service.validateResponse(mockResponse, validNonce, validTimestamp);
+    await service.validateResponse(validText, allHeaders, validNonce, validTimestamp);
   })
 });

--- a/tests/unit/services/request-signer-test.js
+++ b/tests/unit/services/request-signer-test.js
@@ -79,9 +79,10 @@ module('Unit | Services | request-signer', function(hooks) {
     assert.expect(2);
 
     let signerMock = {
-      getHeaders(params) {
+      getFetchHeaders(params) {
         assert.notOk(params.signed_headers, 'No headers are included for the signature.'); // eslint-disable-line camelcase
         assert.equal(params.foo, 'bar', 'Additional parameters are passed through for signature.');
+        return {};
       }
     };
     service.set('signer', signerMock);
@@ -92,9 +93,10 @@ module('Unit | Services | request-signer', function(hooks) {
     assert.expect(2);
 
     let signerMock = {
-      getHeaders(params) {
+      getFetchHeaders(params) {
         assert.deepEqual(params.signed_headers, { 'my-signed-header': 'my-signed-header-value' }, 'Signed headers were included'); // eslint-disable-line camelcase
         assert.equal(params.foo, 'bar', 'Additional parameters are passed through for signature.');
+        return {};
       }
     };
     service.set('signer', signerMock);
@@ -110,9 +112,10 @@ module('Unit | Services | request-signer', function(hooks) {
     assert.expect(2);
 
     let signerMock = {
-      getHeaders(params) {
+      getFetchHeaders(params) {
         assert.notOk(params.signed_headers, 'No headers are included for the signature.'); // eslint-disable-line camelcase
         assert.equal(params.foo, 'bar', 'Additional parameters are passed through for signature.');
+        return {};
       }
     };
     service.set('signer', signerMock);
@@ -129,9 +132,10 @@ module('Unit | Services | request-signer', function(hooks) {
     assert.expect(2);
 
     let signerMock = {
-      getHeaders(params) {
+      getFetchHeaders(params) {
         assert.ok(true, 'Signer was invoked before send.');
         assert.equal(params.method, 'POST', 'It sends the content type to signer.');
+        return {};
       }
     };
 
@@ -148,10 +152,11 @@ module('Unit | Services | request-signer', function(hooks) {
     };
 
     let signerMock = {
-      getHeaders(params) {
+      getFetchHeaders(params) {
         assert.ok(true, 'Signer was invoked before send.');
         assert.equal(params.signed_headers['marvin-suggs'], 'owwww', 'Signed header value was sent.'); // eslint-disable-line camelcase
         assert.notOk(params.signed_headers['mahna-mahna'], 'Unsigned header value was not sent.'); // eslint-disable-line camelcase
+        return {};
       }
     };
 
@@ -164,9 +169,10 @@ module('Unit | Services | request-signer', function(hooks) {
     assert.expect(2);
 
     const signerMock = {
-      getHeaders(params) {
+      getFetchHeaders(params) {
         assert.ok(true, 'Signer was invoked before send.');
         assert.equal(params.body, 'moving right along', 'It sends the body to signer.');
+        return {};
       }
     };
     const requestOptions = { url: 'test-url', data: 'moving right along' };


### PR DESCRIPTION
JIRA issue: [LEB4936](https://backlog.acquia.com/browse/LEB-4936)

Changes:
* updated the `updateAjaxOptions` method to call `getFetchRequest` and to return the `nonce` and `timestamp`
* updated the `validateResponse` to handle a Fetch Response and call `hasValidFetchResponse`
* added tests to cover `validateResponse`
* updated the version to **v2.1.0**, since this is not a breaking change