### PR TITLE
UPDATE LEB-4936 | Update http-hmac-javascript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-http-hmac",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13237,8 +13237,8 @@
       }
     },
     "http-hmac-javascript": {
-      "version": "git+https://github.com/acquia/http-hmac-javascript.git#f06f1a1fdb222dc22f6332ab9df22276a97934cd",
-      "from": "git+https://github.com/acquia/http-hmac-javascript.git#v0.3.0",
+      "version": "git+https://github.com/acquia/http-hmac-javascript.git#8d44eec25ace1da5cd4305f745ac4320fa57dfa1",
+      "from": "git+https://github.com/acquia/http-hmac-javascript.git#8d44eec25ace1da5cd4305f745ac4320fa57dfa1",
       "requires": {
         "crypto-js": "^3.1.6",
         "xmlhttprequest": "^1.8.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13237,8 +13237,8 @@
       }
     },
     "http-hmac-javascript": {
-      "version": "git+https://github.com/acquia/http-hmac-javascript.git#8d44eec25ace1da5cd4305f745ac4320fa57dfa1",
-      "from": "git+https://github.com/acquia/http-hmac-javascript.git#8d44eec25ace1da5cd4305f745ac4320fa57dfa1",
+      "version": "git+https://github.com/acquia/http-hmac-javascript.git#b5aca27578c4a98025540e815fa0ea01de0a33b3",
+      "from": "git+https://github.com/acquia/http-hmac-javascript.git#v0.3.1",
       "requires": {
         "crypto-js": "^3.1.6",
         "xmlhttprequest": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-http-hmac",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Provides an Ember wrapper around Acquia's http-hmac-javascript library.",
   "scripts": {
     "build": "ember build",
@@ -23,7 +23,7 @@
     "crypto-js": "^3.1.6",
     "ember-cli-babel": "^7.13.0",
     "ember-cli-htmlbars": "^4.2.0",
-    "http-hmac-javascript": "git+https://github.com/acquia/http-hmac-javascript.git#v0.3.0",
+    "http-hmac-javascript": "git+https://github.com/acquia/http-hmac-javascript.git#8d44eec25ace1da5cd4305f745ac4320fa57dfa1",
     "xmlhttprequest": "^1.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "crypto-js": "^3.1.6",
     "ember-cli-babel": "^7.13.0",
     "ember-cli-htmlbars": "^4.2.0",
-    "http-hmac-javascript": "git+https://github.com/acquia/http-hmac-javascript.git#8d44eec25ace1da5cd4305f745ac4320fa57dfa1",
+    "http-hmac-javascript": "git+https://github.com/acquia/http-hmac-javascript.git#v0.3.1",
     "xmlhttprequest": "^1.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Changes:
* updates **http-hmac-javascript** to **v0.3.1**, which fixes the response headers getter